### PR TITLE
JWKSのbase64エンコードがurlセーフになっていなかった問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,15 +11,13 @@
     "base64-url": "^2.3.3",
     "fastify": "^3.29.0",
     "jsonwebtoken": "^8.2.0",
-    "node-forge": "^1.3.1",
-    "node-rsa": "^0.4.2"
+    "node-forge": "^1.3.1"
   },
   "devDependencies": {
     "@types/base64-url": "^2.2.0",
     "@types/jsonwebtoken": "^7.2.5",
     "@types/node": "^17.0.35",
     "@types/node-forge": "^1.0.2",
-    "@types/node-rsa": "^0.4.3",
     "typescript": "^4.6.4"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,10 @@ const bootstrap = () => {
   const token = {
     aud: `${jwtAudience}`,
     iss: `${jwksOrigin}`,
+    exp: Date.parse("2099-12-31T23:59:59Z"),
     sub: 'testprovider|12345678',
   }
-  
+
   const server = fastify()
 
   server.get(jwksPath, async () => {
@@ -26,7 +27,7 @@ const bootstrap = () => {
   server.get('/token', async () => {
     return signJwt(keypair.privateKey, token, JWKS.keys[0].kid)
   })
-  
+
   server.listen(8080, '0.0.0.0', (err, address) => {
     if (err) {
       console.error(err)
@@ -34,6 +35,6 @@ const bootstrap = () => {
     }
     console.log(`Server listening at ${address}`)
   })
-  
+
 }
 bootstrap()

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,13 +33,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node-rsa@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@types/node-rsa/-/node-rsa-0.4.3.tgz#7e87b819f654780445dffabb49d4ad7e8d2eec36"
-  integrity sha512-WIqdmZ1jyTuYERTeZ7Af/QgcKvCvhbnhdTsoZuFidtjASoubklRFqLJ+G4MaygJvNFHE86KiuxxPUG4dPoWMww==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*", "@types/node@^17.0.35":
   version "17.0.35"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.35.tgz#635b7586086d51fb40de0a2ec9d1014a5283ba4a"
@@ -74,11 +67,6 @@ archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==
-
-asn1@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
-  integrity sha512-6i37w/+EhlWlGUJff3T/Q8u1RGmP5wgbiwYnOnbOqvtrPxT63/sYFyP9RcpxtxGymtfA075IvmOnL7ycNOWl3w==
 
 atomic-sleep@^1.0.0:
   version "1.0.0"
@@ -326,13 +314,6 @@ node-forge@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
-
-node-rsa@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/node-rsa/-/node-rsa-0.4.2.tgz#d6391729ec16a830ed5a38042b3157d2d5d72530"
-  integrity sha1-1jkXKewWqDDtWjgEKzFX0tXXJTA=
-  dependencies:
-    asn1 "0.2.3"
 
 pino-std-serializers@^3.1.0:
   version "3.2.0"


### PR DESCRIPTION
表題の通りです。btoaを使った標準のbase64文字列はRFCの通り（ https://datatracker.ietf.org/doc/id/draft-jones-json-web-key-01.html#base64urllogic ）MUST NOT で使用しないよう規定されています。

これらを回避するためのbase64urlのライブラリ自体は読み込まれていたものの、使用されていない箇所があり環境によって不具合が発生していたため修正しました